### PR TITLE
Status line for ongoing busy actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up GNAT toolchain
+      run: >
+        sudo apt-get update && 
+        sudo apt-get install gnat gprbuild
+
+    - name: Build
+      run: gprbuild -j0 -p

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![build](https://github.com/alire-project/simple_logging/workflows/Build/badge.svg)](https://github.com/alire-project/simple_logging/actions)
+
 # simple_logging
 
 Easy-to-use logging facilities for output to console in Ada programs.

--- a/src/simple_logging.ads
+++ b/src/simple_logging.ads
@@ -1,6 +1,11 @@
 with GNAT.Source_Info;
 
+private with Ada.Finalization;
+
 package Simple_Logging with Preelaborate is
+
+   --  NOTE: this library is thread-unsafe. Using it with multithreaded
+   --  applications will likely result in mangled output.
 
    --  Since the purpose is to have simultaneously "simple" yet flexible
    --  logging, this package enables the configuration of a single logger
@@ -52,5 +57,45 @@ package Simple_Logging with Preelaborate is
                       Entity   : String := Gnat.Source_Info.Enclosing_Entity;
                       Location : String := Gnat.Source_Info.Source_Location)
    is null; -- Quietly drop
+
+   -----------------
+   -- Status line --
+   -----------------
+
+   type Ongoing (<>) is tagged limited private;
+   --  The status line is used to present an ongoing activity. This is done
+   --  through a scoped type. Several nested statuses can be created, and the
+   --  trailing '...' is added by this prompt. The rest of logging subprograms
+   --  will emit normally over the status line.
+
+   function Activity (Text : String;
+                      Level : Levels := Info) return Ongoing;
+
+   procedure Step (This : in out Ongoing);
+   --  Say that progress was made, which will advance the spinner
+
+private
+
+   type Ongoing_Data (Len : Natural) is record
+      Level : Levels;
+      Text  : String (1 .. Len);
+   end record;
+   --  Non-limited data to be stored in collections
+
+   type Ongoing (Len : Natural)
+   is new Ada.Finalization.Limited_Controlled with record
+      Data : Ongoing_Data (Len => Len);
+   end record;
+
+   function "<" (L, R : Ongoing_Data) return Boolean is
+     (L.Level < R.Level or else
+      (L.Level = R.Level and then L.Text < R.Text));
+
+   overriding
+   procedure Finalize (This : in out Ongoing);
+
+   function Build_Status_Line return String;
+
+   procedure Clear_Status_Line;
 
 end Simple_Logging;


### PR DESCRIPTION
The status line appears below all normal log messages whenever a busy status is alive. Regular logs can still be output, and scroll up above the status line.

Busy statuses are created with a controlled object that will autoremove the status once it goes out of scope. In case of nested instances, they're appended, e.g.:

`◴ Looking for externals... Detecting libsdl2...`

The implementation relies on basic carriage return characters, so it should work in common terminals.