### PR TITLE
New `Is_TTY` flag to disable status line output

### DIFF
--- a/src/simple_logging.ads
+++ b/src/simple_logging.ads
@@ -25,6 +25,11 @@ package Simple_Logging with Preelaborate is
    Level : Levels := Info;
    --  Any message at the same level or below will be output to console
 
+   Is_TTY : Boolean := True;
+   --  Set this to false when you know log is being redirected. This flag
+   --  suppresses the use of busy statuses (see below) which, by relying
+   --  on ASCII.CR, will greatly pollute logfiles.
+
    procedure Log (Message  : String;
                   Level    : Levels := Info;
                   Entity   : String := Gnat.Source_Info.Enclosing_Entity;


### PR DESCRIPTION
Control characters are likely not wanted when redirecting output to files/pipes. This flag allows disabling that output.

The status updates are logged at debug level to ensure the information is not lost at the most detailed log level.