### PR TITLE
Truncate status when necessary

### DIFF
--- a/simple_logging.gpr
+++ b/simple_logging.gpr
@@ -7,6 +7,8 @@ project Simple_Logging is
    for Object_Dir use "obj";
    for Library_Dir use "lib";
 
+   for Languages use ("C", "Ada");
+
    package Builder is
       for Switches ("ada") use ("-j0", "-g");
    end Builder;

--- a/src/simple_logging.adb
+++ b/src/simple_logging.adb
@@ -5,6 +5,8 @@ with GNAT.IO;
 with Simple_Logging.Decorators;
 with Simple_Logging.Filtering;
 
+with Interfaces.C;
+
 pragma Warnings (Off);
 --  This is compiler-internal unit. We only use the Clock, which is highly
 --  unlikely to change its specification.
@@ -12,6 +14,9 @@ with System.OS_Primitives;
 pragma Warnings (On);
 
 package body Simple_Logging is
+   function Get_Term_Width return Interfaces.C.Int;
+   pragma Import
+      (Convention => C, Entity => Get_Term_Width, External_Name => "simple_logging_term_width");
 
    ---------
    -- Log --
@@ -172,6 +177,8 @@ package body Simple_Logging is
       Line : Unbounded_String;
       Pred : Unbounded_String;
       --  Status of the precedent scope, to eliminate duplicates
+
+      Effective_Length : Integer;
    begin
       for Status of Statuses loop
          if Status.Level <= Simple_Logging.Level
@@ -187,7 +194,12 @@ package body Simple_Logging is
          Line := Indicator & " " & Line;
       end if;
 
-      return To_String (Line);
+      Effective_Length := Integer (Get_Term_Width);
+      if Effective_Length = -1 or else Effective_Length > Length (Line) then
+         Effective_Length := Length (Line);
+      end if;
+
+      return To_String (Head (Line, Effective_Length));
    end Build_Status_Line;
 
    -----------------------
@@ -255,5 +267,4 @@ package body Simple_Logging is
          end if;
       end;
    end Step;
-
 end Simple_Logging;

--- a/src/simple_logging.ads
+++ b/src/simple_logging.ads
@@ -18,7 +18,7 @@ package Simple_Logging with Preelaborate is
    --  Strings should be encoded in the expected terminal encoding, which in
    --  this day and age should be UTF-8 for both Linux and Windows. This is
    --  likely to change in the future to require Unicode encoding so text
-   --  lenghts can be computed properly.
+   --  lengths can be computed properly.
 
    type Levels is (Always,
                    Error,

--- a/src/term.c
+++ b/src/term.c
@@ -1,3 +1,5 @@
+#ifdef __linux__
+
 #include <stdbool.h>
 #include <sys/ioctl.h>
 #include <termios.h>
@@ -19,3 +21,12 @@ int simple_logging_term_width(void)
 		return x.ws_col;
 	}
 }
+
+#else // #ifdef __linux__
+
+int simple_logging_term_width(void)
+{
+  return -1;
+}
+
+#endif // #ifdef __linux__

--- a/src/term.c
+++ b/src/term.c
@@ -1,0 +1,21 @@
+#include <stdbool.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+
+bool ioctl_failure = false;
+
+int simple_logging_term_width(void)
+{
+	struct winsize x;
+	int r;
+
+	if (ioctl_failure) return -1;
+	r = ioctl(2, TIOCGWINSZ, &x);
+
+	if (r != 0) {
+		ioctl_failure = true;
+		return -1;
+	} else {
+		return x.ws_col;
+	}
+}


### PR DESCRIPTION
Would fix alire-project/alire#1329.

I tested only on Linux, and to be honest, I don't quite know what this patch does to platform support. I doubt there's any witchcraft capable of making this work on Windows; I've no idea what MacOS supports; and while I assume the ioctl's are the same on the various BSD's, I didn't check. @mosteo would you be able to clarify what platforms need to be tested?